### PR TITLE
Make tests pass

### DIFF
--- a/bridges/bin/runtime-common/Cargo.toml
+++ b/bridges/bin/runtime-common/Cargo.toml
@@ -70,6 +70,9 @@ std = [
 	"sp-weights/std",
 	"tuplex/std",
 	"xcm/std",
+	"bp-test-utils/std",
+	"pallet-balances/std",
+	"sp-core/std"
 ]
 runtime-benchmarks = [
 	"bp-runtime/test-helpers",
@@ -84,6 +87,7 @@ runtime-benchmarks = [
 	"pallet-utility/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-trie",
+	"pallet-balances/runtime-benchmarks"
 ]
 integrity-test = ["static_assertions"]
 test-helpers = ["bp-runtime/test-helpers", "sp-trie"]

--- a/bridges/modules/beefy/Cargo.toml
+++ b/bridges/modules/beefy/Cargo.toml
@@ -52,4 +52,6 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-beefy-mmr/try-runtime",
+	"pallet-mmr/try-runtime"
 ]

--- a/bridges/modules/messages/Cargo.toml
+++ b/bridges/modules/messages/Cargo.toml
@@ -47,6 +47,11 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-trie/std",
+	"pallet-bridge-grandpa/std",
+	"bp-test-utils/std",
+	"pallet-balances/std",
+	"sp-core/std",
+	"sp-io/std"
 ]
 runtime-benchmarks = [
 	"bp-runtime/test-helpers",
@@ -54,10 +59,14 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-bridge-grandpa/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-bridge-grandpa/try-runtime",
+	"pallet-balances/try-runtime"
 ]
 test-helpers = ["bp-runtime/test-helpers", "sp-trie"]

--- a/bridges/modules/relayers/Cargo.toml
+++ b/bridges/modules/relayers/Cargo.toml
@@ -60,6 +60,12 @@ std = [
 	"sp-arithmetic/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"bp-parachains/std",
+	"bp-polkadot-core/std",
+	"bp-test-utils/std",
+	"pallet-utility/std",
+	"sp-core/std",
+	"sp-io/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -70,6 +76,8 @@ runtime-benchmarks = [
 	"pallet-bridge-parachains/runtime-benchmarks",
 	"pallet-transaction-payment/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-utility/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -79,5 +87,7 @@ try-runtime = [
 	"pallet-bridge-parachains/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-utility/try-runtime"
 ]
 integrity-test = []

--- a/bridges/modules/xcm-bridge-hub/Cargo.toml
+++ b/bridges/modules/xcm-bridge-hub/Cargo.toml
@@ -54,6 +54,12 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"pallet-xcm-bridge-hub-router/std",
+	"bp-header-chain/std",
+	"bp-xcm-bridge-hub-router/std",
+	"polkadot-parachain-primitives/std",
+	"pallet-balances/std",
+	"sp-io/std"
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
@@ -62,10 +68,15 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"pallet-xcm-bridge-hub-router/runtime-benchmarks",
+	"polkadot-parachain-primitives/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-bridge-messages/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-xcm-bridge-hub-router/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/bridges/snowbridge/pallets/inbound-queue/Cargo.toml
+++ b/bridges/snowbridge/pallets/inbound-queue/Cargo.toml
@@ -79,10 +79,12 @@ runtime-benchmarks = [
 	"snowbridge-router-primitives/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"snowbridge-pallet-ethereum-client/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-balances/try-runtime",
 	"sp-runtime/try-runtime",
+	"snowbridge-pallet-ethereum-client/try-runtime"
 ]

--- a/bridges/snowbridge/pallets/outbound-queue/Cargo.toml
+++ b/bridges/snowbridge/pallets/outbound-queue/Cargo.toml
@@ -53,6 +53,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"pallet-message-queue/std"
 ]
 runtime-benchmarks = [
 	"bridge-hub-common/runtime-benchmarks",
@@ -62,9 +63,11 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"snowbridge-core/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-message-queue/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-message-queue/try-runtime"
 ]

--- a/bridges/snowbridge/pallets/system/Cargo.toml
+++ b/bridges/snowbridge/pallets/system/Cargo.toml
@@ -64,9 +64,16 @@ runtime-benchmarks = [
 	"snowbridge-core/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"snowbridge-pallet-outbound-queue/runtime-benchmarks",
+	"polkadot-primitives/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-message-queue/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"snowbridge-pallet-outbound-queue/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-message-queue/try-runtime"
 ]

--- a/bridges/snowbridge/primitives/core/Cargo.toml
+++ b/bridges/snowbridge/primitives/core/Cargo.toml
@@ -55,4 +55,10 @@ std = [
 ]
 serde = ["dep:serde", "scale-info/serde"]
 runtime-benchmarks = [
+	"polkadot-parachain-primitives/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks"
 ]

--- a/cumulus/pallets/collator-selection/Cargo.toml
+++ b/cumulus/pallets/collator-selection/Cargo.toml
@@ -47,6 +47,7 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]
 std = [
 	"codec/std",
@@ -70,4 +71,6 @@ try-runtime = [
 	"pallet-balances/try-runtime",
 	"pallet-session/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-aura/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]

--- a/cumulus/pallets/parachain-system/Cargo.toml
+++ b/cumulus/pallets/parachain-system/Cargo.toml
@@ -103,6 +103,7 @@ runtime-benchmarks = [
 	"polkadot-runtime-parachains/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
+	"cumulus-test-client/runtime-benchmarks"
 ]
 
 try-runtime = [

--- a/cumulus/pallets/xcmp-queue/Cargo.toml
+++ b/cumulus/pallets/xcmp-queue/Cargo.toml
@@ -73,6 +73,8 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"cumulus-pallet-parachain-system/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -81,5 +83,7 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"polkadot-runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
+	"cumulus-pallet-parachain-system/try-runtime",
+	"pallet-balances/try-runtime"
 ]
 bridging = ["bp-xcm-bridge-hub-router"]

--- a/cumulus/parachains/pallets/collective-content/Cargo.toml
+++ b/cumulus/parachains/pallets/collective-content/Cargo.toml
@@ -44,4 +44,5 @@ std = [
 	"scale-info/std",
 	"sp-core/std",
 	"sp-runtime/std",
+	"sp-io/std"
 ]

--- a/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-rococo/src/lib.rs
@@ -1429,7 +1429,8 @@ impl_runtime_apis! {
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
 			let native_asset = xcm_config::TokenLocation::get();
 			let fee_in_native = WeightToFee::weight_to_fee(&weight);
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == native_asset => {
 					// for native token
 					Ok(fee_in_native)

--- a/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -1474,7 +1474,8 @@ impl_runtime_apis! {
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
 			let native_asset = xcm_config::WestendLocation::get();
 			let fee_in_native = WeightToFee::weight_to_fee(&weight);
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == native_asset => {
 					// for native asset
 					Ok(fee_in_native)

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -249,6 +249,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"snowbridge-runtime-test-common/runtime-benchmarks"
 ]
 
 try-runtime = [

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -846,7 +846,8 @@ impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::TokenLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/Cargo.toml
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/Cargo.toml
@@ -248,6 +248,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"snowbridge-runtime-test-common/runtime-benchmarks"
 ]
 
 try-runtime = [

--- a/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/lib.rs
@@ -778,7 +778,8 @@ impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::WestendLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/collectives/collectives-westend/src/lib.rs
@@ -961,7 +961,8 @@ impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::WndLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-rococo/src/lib.rs
@@ -813,7 +813,8 @@ impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::RocRelayLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/coretime/coretime-westend/src/lib.rs
@@ -805,7 +805,8 @@ impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::TokenRelayLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-rococo/src/lib.rs
@@ -781,7 +781,8 @@ impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::RelayLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
+++ b/cumulus/parachains/runtimes/people/people-westend/src/lib.rs
@@ -779,7 +779,8 @@ impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == xcm_config::RelayLocation::get() => {
 					// for native token
 					Ok(WeightToFee::weight_to_fee(&weight))

--- a/cumulus/polkadot-parachain/Cargo.toml
+++ b/cumulus/polkadot-parachain/Cargo.toml
@@ -64,6 +64,23 @@ substrate-build-script-utils.default-features = true
 [features]
 default = []
 runtime-benchmarks = [
+	"parachains-common/runtime-benchmarks",
+	"asset-hub-rococo-runtime/runtime-benchmarks",
+	"asset-hub-westend-runtime/runtime-benchmarks",
+	"bridge-hub-rococo-runtime/runtime-benchmarks",
+	"bridge-hub-westend-runtime/runtime-benchmarks",
+	"collectives-westend-runtime/runtime-benchmarks",
+	"contracts-rococo-runtime/runtime-benchmarks",
+	"coretime-rococo-runtime/runtime-benchmarks",
+	"coretime-westend-runtime/runtime-benchmarks",
+	"glutton-westend-runtime/runtime-benchmarks",
+	"people-rococo-runtime/runtime-benchmarks",
+	"people-westend-runtime/runtime-benchmarks",
+	"penpal-runtime/runtime-benchmarks",
+	"rococo-parachain-runtime/runtime-benchmarks",
+	"polkadot-omni-node-lib/runtime-benchmarks",
+	"cumulus-primitives-core/runtime-benchmarks",
+	"sc-service/runtime-benchmarks"
 ]
 try-runtime = [
 	"polkadot-omni-node-lib/try-runtime",

--- a/cumulus/primitives/storage-weight-reclaim/Cargo.toml
+++ b/cumulus/primitives/storage-weight-reclaim/Cargo.toml
@@ -38,4 +38,6 @@ std = [
 	"log/std",
 	"scale-info/std",
 	"sp-runtime/std",
+	"sp-io/std",
+	"sp-trie/std"
 ]

--- a/cumulus/test/service/Cargo.toml
+++ b/cumulus/test/service/Cargo.toml
@@ -165,6 +165,7 @@ runtime-benchmarks = [
 	"polkadot-test-service/runtime-benchmarks",
 	"sc-service/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"cumulus-test-client/runtime-benchmarks"
 ]
 
 [[bench]]

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -49,4 +49,5 @@ runtime-metrics = []
 runtime-benchmarks = [
 	"polkadot-primitives/runtime-benchmarks",
 	"sc-service/runtime-benchmarks",
+	"polkadot-test-service/runtime-benchmarks"
 ]

--- a/polkadot/node/service/Cargo.toml
+++ b/polkadot/node/service/Cargo.toml
@@ -253,6 +253,7 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"westend-runtime?/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"polkadot-test-client/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-system/try-runtime",

--- a/polkadot/runtime/common/Cargo.toml
+++ b/polkadot/runtime/common/Cargo.toml
@@ -156,4 +156,5 @@ try-runtime = [
 	"pallet-vesting/try-runtime",
 	"polkadot-runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
+	"frame-support-test/try-runtime"
 ]

--- a/polkadot/runtime/parachains/Cargo.toml
+++ b/polkadot/runtime/parachains/Cargo.toml
@@ -151,6 +151,7 @@ try-runtime = [
 	"pallet-timestamp/try-runtime",
 	"pallet-vesting/try-runtime",
 	"sp-runtime/try-runtime",
+	"frame-support-test/try-runtime"
 ]
 runtime-metrics = [
 	"polkadot-runtime-metrics/runtime-metrics",

--- a/polkadot/runtime/rococo/Cargo.toml
+++ b/polkadot/runtime/rococo/Cargo.toml
@@ -214,6 +214,7 @@ std = [
 	"xcm-executor/std",
 	"xcm-runtime-apis/std",
 	"xcm/std",
+	"sp-tracing/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/polkadot/runtime/westend/Cargo.toml
+++ b/polkadot/runtime/westend/Cargo.toml
@@ -231,6 +231,7 @@ std = [
 	"xcm-executor/std",
 	"xcm-runtime-apis/std",
 	"xcm/std",
+	"sp-tracing/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml
@@ -57,4 +57,9 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"polkadot-primitives/runtime-benchmarks",
+	"polkadot-runtime-common/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]

--- a/polkadot/xcm/pallet-xcm/Cargo.toml
+++ b/polkadot/xcm/pallet-xcm/Cargo.toml
@@ -61,10 +61,15 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"polkadot-parachain-primitives/runtime-benchmarks",
+	"polkadot-runtime-parachains/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-balances/try-runtime",
 	"sp-runtime/try-runtime",
+	"polkadot-runtime-parachains/try-runtime",
+	"pallet-assets/try-runtime"
 ]

--- a/polkadot/xcm/xcm-builder/Cargo.toml
+++ b/polkadot/xcm/xcm-builder/Cargo.toml
@@ -48,6 +48,13 @@ runtime-benchmarks = [
 	"polkadot-parachain-primitives/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"polkadot-primitives/runtime-benchmarks",
+	"polkadot-runtime-parachains/runtime-benchmarks",
+	"polkadot-test-runtime/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-salary/runtime-benchmarks"
 ]
 std = [
 	"codec/std",
@@ -64,4 +71,5 @@ std = [
 	"sp-weights/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"primitive-types/std"
 ]

--- a/polkadot/xcm/xcm-runtime-apis/Cargo.toml
+++ b/polkadot/xcm/xcm-runtime-apis/Cargo.toml
@@ -42,8 +42,21 @@ std = [
 	"sp-weights/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"pallet-xcm/std",
+	"xcm-builder/std",
+	"pallet-assets/std",
+	"pallet-balances/std",
+	"frame-executive/std",
+	"frame-system/std",
+	"sp-io/std",
+	"log/std"
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"frame-system/runtime-benchmarks"
 ]

--- a/polkadot/xcm/xcm-runtime-apis/tests/mock.rs
+++ b/polkadot/xcm/xcm-runtime-apis/tests/mock.rs
@@ -469,7 +469,8 @@ sp_api::mock_impl_runtime_apis! {
 		}
 
 		fn query_weight_to_asset_fee(weight: Weight, asset: VersionedAssetId) -> Result<u128, XcmPaymentApiError> {
-			match asset.try_as::<AssetId>() {
+			let latest_asset_id: Result<AssetId, ()> = asset.clone().try_into();
+			match latest_asset_id {
 				Ok(asset_id) if asset_id.0 == HereLocation::get() => {
 					Ok(WeightToFee::weight_to_fee(&weight))
 				},

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -94,6 +94,7 @@ runtime-benchmarks = [
 try-runtime = [
 	"kitchensink-runtime/try-runtime",
 	"polkadot-sdk/try-runtime",
+	"substrate-cli-test-utils/try-runtime"
 ]
 
 [[bench]]

--- a/substrate/client/db/Cargo.toml
+++ b/substrate/client/db/Cargo.toml
@@ -63,6 +63,7 @@ default = []
 test-helpers = []
 runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
+	"kitchensink-runtime/runtime-benchmarks"
 ]
 rocksdb = ["kvdb-rocksdb"]
 

--- a/substrate/frame/Cargo.toml
+++ b/substrate/frame/Cargo.toml
@@ -114,4 +114,5 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-examples/try-runtime"
 ]

--- a/substrate/frame/alliance/Cargo.toml
+++ b/substrate/frame/alliance/Cargo.toml
@@ -62,6 +62,7 @@ runtime-benchmarks = [
 	"pallet-identity/runtime-benchmarks",
 	"sp-crypto-hashing",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -69,4 +70,5 @@ try-runtime = [
 	"pallet-collective?/try-runtime",
 	"pallet-identity/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/asset-conversion/Cargo.toml
+++ b/substrate/frame/asset-conversion/Cargo.toml
@@ -47,15 +47,20 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"primitive-types/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-assets/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/asset-conversion/ops/Cargo.toml
+++ b/substrate/frame/asset-conversion/ops/Cargo.toml
@@ -46,6 +46,7 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"primitive-types/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -53,10 +54,14 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-asset-conversion/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-asset-conversion/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-assets/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/asset-rate/Cargo.toml
+++ b/substrate/frame/asset-rate/Cargo.toml
@@ -47,9 +47,11 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"sp-core",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/assets-freezer/Cargo.toml
+++ b/substrate/frame/assets-freezer/Cargo.toml
@@ -40,6 +40,9 @@ std = [
 	"pallet-assets/std",
 	"scale-info/std",
 	"sp-runtime/std",
+	"pallet-balances/std",
+	"sp-core/std",
+	"sp-io/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -47,10 +50,12 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-assets/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/assets/Cargo.toml
+++ b/substrate/frame/assets/Cargo.toml
@@ -47,9 +47,11 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/atomic-swap/Cargo.toml
+++ b/substrate/frame/atomic-swap/Cargo.toml
@@ -42,4 +42,5 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/aura/Cargo.toml
+++ b/substrate/frame/aura/Cargo.toml
@@ -42,6 +42,7 @@ std = [
 	"sp-application-crypto/std",
 	"sp-consensus-aura/std",
 	"sp-runtime/std",
+	"sp-core/std"
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/substrate/frame/babe/Cargo.toml
+++ b/substrate/frame/babe/Cargo.toml
@@ -68,6 +68,10 @@ runtime-benchmarks = [
 	"pallet-timestamp/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"frame-election-provider-support/runtime-benchmarks",
+	"pallet-offences/runtime-benchmarks",
+	"pallet-staking/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -76,4 +80,8 @@ try-runtime = [
 	"pallet-session/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"frame-election-provider-support/try-runtime",
+	"pallet-offences/try-runtime",
+	"pallet-staking/try-runtime"
 ]

--- a/substrate/frame/balances/Cargo.toml
+++ b/substrate/frame/balances/Cargo.toml
@@ -50,9 +50,11 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-transaction-payment/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-transaction-payment/try-runtime"
 ]

--- a/substrate/frame/beefy-mmr/Cargo.toml
+++ b/substrate/frame/beefy-mmr/Cargo.toml
@@ -71,4 +71,5 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-mmr/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"sp-staking/runtime-benchmarks"
 ]

--- a/substrate/frame/beefy/Cargo.toml
+++ b/substrate/frame/beefy/Cargo.toml
@@ -52,6 +52,7 @@ std = [
 	"sp-runtime/std",
 	"sp-session/std",
 	"sp-staking/std",
+	"sp-state-machine/std"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -59,4 +60,9 @@ try-runtime = [
 	"pallet-authorship/try-runtime",
 	"pallet-session/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"frame-election-provider-support/try-runtime",
+	"pallet-offences/try-runtime",
+	"pallet-staking/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]

--- a/substrate/frame/bounties/Cargo.toml
+++ b/substrate/frame/bounties/Cargo.toml
@@ -52,10 +52,12 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-treasury/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/child-bounties/Cargo.toml
+++ b/substrate/frame/child-bounties/Cargo.toml
@@ -56,6 +56,7 @@ runtime-benchmarks = [
 	"pallet-bounties/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -63,4 +64,5 @@ try-runtime = [
 	"pallet-bounties/try-runtime",
 	"pallet-treasury/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/collective/Cargo.toml
+++ b/substrate/frame/collective/Cargo.toml
@@ -42,15 +42,18 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"pallet-balances/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/contracts/Cargo.toml
+++ b/substrate/frame/contracts/Cargo.toml
@@ -110,10 +110,21 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"wasm-instrument",
 	"xcm-builder/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-message-queue/runtime-benchmarks",
+	"pallet-proxy/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks",
+	"pallet-utility/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-balances/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-assets/try-runtime",
+	"pallet-insecure-randomness-collective-flip/try-runtime",
+	"pallet-message-queue/try-runtime",
+	"pallet-proxy/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-utility/try-runtime"
 ]

--- a/substrate/frame/conviction-voting/Cargo.toml
+++ b/substrate/frame/conviction-voting/Cargo.toml
@@ -51,9 +51,13 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-scheduler/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-scheduler/try-runtime"
 ]

--- a/substrate/frame/delegated-staking/Cargo.toml
+++ b/substrate/frame/delegated-staking/Cargo.toml
@@ -44,15 +44,26 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-staking/std",
+	"frame-election-provider-support/std"
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"frame-election-provider-support/runtime-benchmarks",
+	"pallet-nomination-pools/runtime-benchmarks",
+	"pallet-staking/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"frame-election-provider-support/try-runtime",
+	"pallet-nomination-pools/try-runtime",
+	"pallet-staking/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]

--- a/substrate/frame/democracy/Cargo.toml
+++ b/substrate/frame/democracy/Cargo.toml
@@ -53,9 +53,15 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-preimage/runtime-benchmarks",
+	"pallet-scheduler/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-preimage/try-runtime",
+	"pallet-scheduler/try-runtime"
 ]

--- a/substrate/frame/election-provider-multi-phase/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/Cargo.toml
@@ -73,10 +73,12 @@ runtime-benchmarks = [
 	"rand",
 	"sp-runtime/runtime-benchmarks",
 	"strum",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-election-provider-support/try-runtime",
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/election-provider-multi-phase/test-staking-e2e/Cargo.toml
+++ b/substrate/frame/election-provider-multi-phase/test-staking-e2e/Cargo.toml
@@ -43,4 +43,15 @@ pallet-session = { default-features = true, path = "../../session" }
 
 [features]
 try-runtime = [
+	"pallet-bags-list/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-election-provider-multi-phase/try-runtime",
+	"frame-election-provider-support/try-runtime",
+	"pallet-nomination-pools/try-runtime",
+	"pallet-session/try-runtime",
+	"pallet-staking/try-runtime",
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"sp-runtime/try-runtime"
 ]

--- a/substrate/frame/elections-phragmen/Cargo.toml
+++ b/substrate/frame/elections-phragmen/Cargo.toml
@@ -57,9 +57,11 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/examples/authorization-tx-extension/Cargo.toml
+++ b/substrate/frame/examples/authorization-tx-extension/Cargo.toml
@@ -42,15 +42,19 @@ std = [
 	"scale-info/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"pallet-verify-signature/std",
+	"sp-core/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-verify-signature/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-verify-signature/try-runtime"
 ]

--- a/substrate/frame/examples/basic/Cargo.toml
+++ b/substrate/frame/examples/basic/Cargo.toml
@@ -42,6 +42,7 @@ std = [
 	"scale-info/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/examples/dev-mode/Cargo.toml
+++ b/substrate/frame/examples/dev-mode/Cargo.toml
@@ -39,6 +39,7 @@ std = [
 	"scale-info/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std"
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/substrate/frame/examples/kitchensink/Cargo.toml
+++ b/substrate/frame/examples/kitchensink/Cargo.toml
@@ -41,6 +41,7 @@ std = [
 	"scale-info/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/examples/split/Cargo.toml
+++ b/substrate/frame/examples/split/Cargo.toml
@@ -38,6 +38,7 @@ std = [
 	"log/std",
 	"scale-info/std",
 	"sp-io/std",
+	"sp-core/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/substrate/frame/executive/Cargo.toml
+++ b/substrate/frame/executive/Cargo.toml
@@ -60,4 +60,6 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-transaction-payment/try-runtime"
 ]

--- a/substrate/frame/fast-unstake/Cargo.toml
+++ b/substrate/frame/fast-unstake/Cargo.toml
@@ -50,6 +50,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-staking/std",
+	"sp-core/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -58,10 +59,16 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-staking/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-election-provider-support/try-runtime",
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-staking/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]

--- a/substrate/frame/glutton/Cargo.toml
+++ b/substrate/frame/glutton/Cargo.toml
@@ -50,6 +50,7 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]
 
 runtime-benchmarks = [
@@ -57,4 +58,5 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]

--- a/substrate/frame/grandpa/Cargo.toml
+++ b/substrate/frame/grandpa/Cargo.toml
@@ -68,6 +68,11 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"frame-election-provider-support/runtime-benchmarks",
+	"pallet-offences/runtime-benchmarks",
+	"pallet-staking/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -75,4 +80,9 @@ try-runtime = [
 	"pallet-authorship/try-runtime",
 	"pallet-session/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"frame-election-provider-support/try-runtime",
+	"pallet-offences/try-runtime",
+	"pallet-staking/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]

--- a/substrate/frame/identity/Cargo.toml
+++ b/substrate/frame/identity/Cargo.toml
@@ -50,9 +50,11 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/im-online/Cargo.toml
+++ b/substrate/frame/im-online/Cargo.toml
@@ -60,4 +60,5 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"pallet-authorship/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-session/try-runtime"
 ]

--- a/substrate/frame/indices/Cargo.toml
+++ b/substrate/frame/indices/Cargo.toml
@@ -48,9 +48,11 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/lottery/Cargo.toml
+++ b/substrate/frame/lottery/Cargo.toml
@@ -45,9 +45,12 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"frame-support-test/try-runtime"
 ]

--- a/substrate/frame/migrations/Cargo.toml
+++ b/substrate/frame/migrations/Cargo.toml
@@ -58,4 +58,5 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"frame-executive/try-runtime"
 ]

--- a/substrate/frame/multisig/Cargo.toml
+++ b/substrate/frame/multisig/Cargo.toml
@@ -36,7 +36,9 @@ std = [
 ]
 runtime-benchmarks = [
 	"frame/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/nft-fractionalization/Cargo.toml
+++ b/substrate/frame/nft-fractionalization/Cargo.toml
@@ -52,6 +52,7 @@ runtime-benchmarks = [
 	"pallet-assets/runtime-benchmarks",
 	"pallet-nfts/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -59,4 +60,5 @@ try-runtime = [
 	"pallet-assets/try-runtime",
 	"pallet-nfts/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/nfts/Cargo.toml
+++ b/substrate/frame/nfts/Cargo.toml
@@ -50,9 +50,11 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/nis/Cargo.toml
+++ b/substrate/frame/nis/Cargo.toml
@@ -46,9 +46,11 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/nomination-pools/benchmarking/Cargo.toml
+++ b/substrate/frame/nomination-pools/benchmarking/Cargo.toml
@@ -55,6 +55,7 @@ std = [
 	"sp-runtime-interface/std",
 	"sp-runtime/std",
 	"sp-staking/std",
+	"pallet-balances/std"
 ]
 
 runtime-benchmarks = [
@@ -68,4 +69,6 @@ runtime-benchmarks = [
 	"pallet-staking/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]

--- a/substrate/frame/offences/benchmarking/Cargo.toml
+++ b/substrate/frame/offences/benchmarking/Cargo.toml
@@ -73,4 +73,5 @@ runtime-benchmarks = [
 	"pallet-staking/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]

--- a/substrate/frame/parameters/Cargo.toml
+++ b/substrate/frame/parameters/Cargo.toml
@@ -42,9 +42,13 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-example-basic/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-example-basic/try-runtime"
 ]

--- a/substrate/frame/preimage/Cargo.toml
+++ b/substrate/frame/preimage/Cargo.toml
@@ -34,6 +34,7 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 std = [
 	"codec/std",
@@ -50,4 +51,5 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/proxy/Cargo.toml
+++ b/substrate/frame/proxy/Cargo.toml
@@ -33,7 +33,11 @@ std = [
 ]
 runtime-benchmarks = [
 	"frame/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-utility/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-utility/try-runtime"
 ]

--- a/substrate/frame/recovery/Cargo.toml
+++ b/substrate/frame/recovery/Cargo.toml
@@ -36,6 +36,7 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	'frame-benchmarking',
+	"pallet-balances/runtime-benchmarks"
 ]
 std = [
 	"codec/std",
@@ -50,4 +51,5 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/referenda/Cargo.toml
+++ b/substrate/frame/referenda/Cargo.toml
@@ -58,9 +58,15 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-preimage/runtime-benchmarks",
+	"pallet-scheduler/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-preimage/try-runtime",
+	"pallet-scheduler/try-runtime"
 ]

--- a/substrate/frame/revive/Cargo.toml
+++ b/substrate/frame/revive/Cargo.toml
@@ -110,6 +110,8 @@ std = [
 	"subxt-signer",
 	"xcm-builder/std",
 	"xcm/std",
+	"secp256k1/std",
+	"serde_json/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -120,6 +122,11 @@ runtime-benchmarks = [
 	"pallet-transaction-payment/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-message-queue/runtime-benchmarks",
+	"pallet-proxy/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks",
+	"pallet-utility/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -127,4 +134,9 @@ try-runtime = [
 	"pallet-balances/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-assets/try-runtime",
+	"pallet-message-queue/try-runtime",
+	"pallet-proxy/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"pallet-utility/try-runtime"
 ]

--- a/substrate/frame/revive/mock-network/Cargo.toml
+++ b/substrate/frame/revive/mock-network/Cargo.toml
@@ -84,6 +84,7 @@ std = [
 	"sp-runtime/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"pallet-revive-fixtures/std"
 ]
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",

--- a/substrate/frame/root-offences/Cargo.toml
+++ b/substrate/frame/root-offences/Cargo.toml
@@ -43,6 +43,9 @@ runtime-benchmarks = [
 	"pallet-staking/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"frame-election-provider-support/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -50,6 +53,9 @@ try-runtime = [
 	"pallet-session/try-runtime",
 	"pallet-staking/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"frame-election-provider-support/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]
 default = ["std"]
 std = [
@@ -61,4 +67,5 @@ std = [
 	"scale-info/std",
 	"sp-runtime/std",
 	"sp-staking/std",
+	"sp-io/std"
 ]

--- a/substrate/frame/scheduler/Cargo.toml
+++ b/substrate/frame/scheduler/Cargo.toml
@@ -37,6 +37,7 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-preimage/runtime-benchmarks"
 ]
 std = [
 	"codec/std",
@@ -48,9 +49,11 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-weights/std",
+	"sp-core/std"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-preimage/try-runtime"
 ]

--- a/substrate/frame/scored-pool/Cargo.toml
+++ b/substrate/frame/scored-pool/Cargo.toml
@@ -41,4 +41,5 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/session/benchmarking/Cargo.toml
+++ b/substrate/frame/session/benchmarking/Cargo.toml
@@ -55,4 +55,7 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"frame-election-provider-support/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]

--- a/substrate/frame/society/Cargo.toml
+++ b/substrate/frame/society/Cargo.toml
@@ -54,9 +54,12 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"frame-support-test/try-runtime"
 ]

--- a/substrate/frame/staking/Cargo.toml
+++ b/substrate/frame/staking/Cargo.toml
@@ -74,6 +74,9 @@ runtime-benchmarks = [
 	"rand_chacha",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"pallet-bags-list/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-election-provider-support/try-runtime",
@@ -82,4 +85,7 @@ try-runtime = [
 	"pallet-authorship/try-runtime",
 	"pallet-session/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-bags-list/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]

--- a/substrate/frame/state-trie-migration/Cargo.toml
+++ b/substrate/frame/state-trie-migration/Cargo.toml
@@ -55,11 +55,13 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]
 remote-test = [
 	"remote-externalities",

--- a/substrate/frame/statement/Cargo.toml
+++ b/substrate/frame/statement/Cargo.toml
@@ -47,4 +47,5 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/support/Cargo.toml
+++ b/substrate/frame/support/Cargo.toml
@@ -99,14 +99,17 @@ std = [
 	"sp-tracing/std",
 	"sp-trie/std",
 	"sp-weights/std",
+	"sp-timestamp/std"
 ]
 runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"frame-system/runtime-benchmarks"
 ]
 try-runtime = [
 	"sp-debug-derive/force-debug",
 	"sp-runtime/try-runtime",
+	"frame-system/try-runtime"
 ]
 experimental = ["frame-support-procedural/experimental"]
 # By default some types have documentation, `no-metadata-docs` allows to reduce the documentation

--- a/substrate/frame/support/procedural/Cargo.toml
+++ b/substrate/frame/support/procedural/Cargo.toml
@@ -53,6 +53,14 @@ static_assertions = { workspace = true }
 default = ["std"]
 std = [
 	"sp-crypto-hashing/std",
+	"frame-support/std",
+	"frame-system/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-metadata-ir/std",
+	"sp-runtime/std",
+	"codec/std",
+	"scale-info/std"
 ]
 no-metadata-docs = []
 experimental = []

--- a/substrate/frame/tips/Cargo.toml
+++ b/substrate/frame/tips/Cargo.toml
@@ -53,10 +53,12 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-treasury/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/transaction-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/Cargo.toml
@@ -50,9 +50,11 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/transaction-payment/asset-conversion-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-conversion-tx-payment/Cargo.toml
@@ -43,6 +43,9 @@ std = [
 	"pallet-transaction-payment/std",
 	"scale-info/std",
 	"sp-runtime/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-storage/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -51,6 +54,8 @@ runtime-benchmarks = [
 	"pallet-asset-conversion/runtime-benchmarks",
 	"pallet-transaction-payment/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -58,4 +63,6 @@ try-runtime = [
 	"pallet-asset-conversion/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-assets/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
+++ b/substrate/frame/transaction-payment/asset-tx-payment/Cargo.toml
@@ -51,6 +51,7 @@ std = [
 	"sp-core/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-storage/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -58,10 +59,15 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-transaction-payment/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-assets/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-assets/try-runtime",
+	"pallet-authorship/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/transaction-storage/Cargo.toml
+++ b/substrate/frame/transaction-storage/Cargo.toml
@@ -57,6 +57,7 @@ std = [
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-transaction-storage-proof/std",
+	"sp-core/std"
 ]
 try-runtime = [
 	"frame-support/try-runtime",

--- a/substrate/frame/treasury/Cargo.toml
+++ b/substrate/frame/treasury/Cargo.toml
@@ -58,10 +58,12 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-utility/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"pallet-balances/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-utility/try-runtime"
 ]

--- a/substrate/frame/uniques/Cargo.toml
+++ b/substrate/frame/uniques/Cargo.toml
@@ -46,9 +46,11 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/utility/Cargo.toml
+++ b/substrate/frame/utility/Cargo.toml
@@ -49,9 +49,16 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-collective/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-collective/try-runtime",
+	"pallet-root-testing/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]

--- a/substrate/frame/verify-signature/Cargo.toml
+++ b/substrate/frame/verify-signature/Cargo.toml
@@ -51,9 +51,16 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-collective/runtime-benchmarks",
+	"pallet-timestamp/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-collective/try-runtime",
+	"pallet-root-testing/try-runtime",
+	"pallet-timestamp/try-runtime"
 ]

--- a/substrate/frame/vesting/Cargo.toml
+++ b/substrate/frame/vesting/Cargo.toml
@@ -41,15 +41,18 @@ std = [
 	"log/std",
 	"scale-info/std",
 	"sp-runtime/std",
+	"sp-io/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime"
 ]

--- a/substrate/frame/whitelist/Cargo.toml
+++ b/substrate/frame/whitelist/Cargo.toml
@@ -46,9 +46,13 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-preimage/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-balances/try-runtime",
+	"pallet-preimage/try-runtime"
 ]

--- a/substrate/test-utils/runtime/Cargo.toml
+++ b/substrate/test-utils/runtime/Cargo.toml
@@ -111,6 +111,7 @@ std = [
 	"substrate-wasm-builder",
 	"tracing/std",
 	"trie-db/std",
+	"serde/std"
 ]
 
 # Special feature to disable logging

--- a/substrate/utils/frame/benchmarking-cli/Cargo.toml
+++ b/substrate/utils/frame/benchmarking-cli/Cargo.toml
@@ -118,5 +118,6 @@ runtime-benchmarks = [
 	"sc-client-db/runtime-benchmarks",
 	"sc-service/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"westend-runtime/runtime-benchmarks"
 ]
 rocksdb = ["sc-cli/rocksdb", "sc-client-db/rocksdb"]

--- a/templates/solochain/pallets/template/Cargo.toml
+++ b/templates/solochain/pallets/template/Cargo.toml
@@ -41,8 +41,10 @@ runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
+	"sp-runtime/try-runtime"
 ]


### PR DESCRIPTION
Had to run `zepter` and apply changes from [this PR](https://github.com/paritytech/polkadot-sdk/pull/6459) which seems to not have been backported to `stable2412`, presumably because it was merged after the cutoff but before the release.
